### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/app8.yml
+++ b/.github/workflows/app8.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish v1 & v5 to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         VERSION: working
       with:
@@ -27,7 +27,7 @@ jobs:
         context: app8
 
     - name: Publish v2 to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         VERSION: broken
       with:
@@ -39,7 +39,7 @@ jobs:
         context: app8
 
     - name: Publish v3 to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         VERSION: random
       with:
@@ -51,7 +51,7 @@ jobs:
         context: app8
 
     - name: Publish v4 to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         VERSION: delayed_broken
       with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore